### PR TITLE
Update asdf-vm/actions action to v4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,10 @@
-name: Main workflow
+name: Builds, tests & co
 
 on:
-  pull_request:
-  push:
-  schedule:
-    - cron: 0 0 * * 5
+  - push
+  - pull_request
+
+permissions: read-all
 
 jobs:
   plugin_test:
@@ -12,66 +12,47 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
-
+          - macos-latest
     runs-on: ${{ matrix.os }}
-
     steps:
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+      - name: Test plugin
+        uses: asdf-vm/actions/plugin-test@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         with:
           command: peco --version
 
   test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up asdf
-        uses: asdf-vm/actions/setup@v1
-
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set-up asdf
+        uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install bats
-        run: brew install bats-core
-
+      - name: Install cram
+        run: brew install cram
       - name: Test plugin
         run: |
-          asdf plugin add peco $GITHUB_WORKSPACE
-          make test
+          asdf plugin add peco .
+          cram test
 
   lint:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install shellcheck
-        run: brew install shellcheck
-
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install tools
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
       - name: Run ShellCheck
         run: make lint
 
   format:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install shfmt
-        run: brew install shfmt
-
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install tools
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
       - name: Run shfmt
         run: make fmt-check

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+shellcheck 0.11.0
+shfmt      3.12.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SH_SRCFILES = $(shell git ls-files "bin/*")
+SH_SRCFILES = $(shell git ls-files "bin/*" "lib/*")
 SHFMT_BASE_FLAGS = -s -i 2 -ci
 
 fmt:
@@ -14,5 +14,5 @@ lint:
 .PHONY: lint
 
 test:
-	bats test
+	cram test
 .PHONY: test

--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+source "${plugin_dir}/lib/utils.bash"
+
+if [ "$ASDF_INSTALL_TYPE" != "version" ]; then
+  fail "asdf-${TOOL_NAME} supports release installs only"
+fi
+
+mkdir -p "$ASDF_DOWNLOAD_PATH"
+
+resolved_version="$(resolve_version "$ASDF_INSTALL_VERSION")"
+release_file="$ASDF_DOWNLOAD_PATH/$(release_filename)"
+
+download_release "$resolved_version" "$release_file"

--- a/bin/install
+++ b/bin/install
@@ -1,72 +1,10 @@
 #!/usr/bin/env bash
 
-set -Eeuo pipefail
+set -euo pipefail
 
-trap cleanup SIGINT SIGTERM ERR
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-tmp_download_dir=$(mktemp -d)
+source "${plugin_dir}/lib/utils.bash"
 
-cleanup() {
-  trap - SIGINT SIGTERM ERR
-  rm -rf "$ASDF_INSTALL_PATH" "$tmp_download_dir"
-  echo
-  echo -e "\e[33mCleanup:\e[m Something went wrong!"
-  echo
-  echo "$(caller): ${BASH_COMMAND}"
-}
-
-fail() {
-  echo -e "\e[31mFail:\e[m $*"
-  exit 1
-}
-
-install_peco() {
-  local install_type=$1
-  local version=$2
-  local install_path=$3
-
-  if [ "$install_type" != "version" ]; then
-    fail "asdf-peco supports release installs only"
-  fi
-
-  local platform
-  local archive_format
-
-  case "$OSTYPE" in
-    darwin*)
-      platform="darwin"
-      archive_format="zip"
-      ;;
-    linux*)
-      platform="linux"
-      archive_format="tar.gz"
-      ;;
-    *) fail "Unsupported platform" ;;
-  esac
-
-  local architecture
-
-  case "$(uname -m)" in
-    aarch64* | arm64) architecture="arm64" ;;
-    armv5* | armv6* | armv7*) architecture="arm" ;;
-    i686*) architecture="386" ;;
-    x86_64*) architecture="amd64" ;;
-    *) fail "Unsupported architecture" ;;
-  esac
-
-  local download_url="https://github.com/peco/peco/releases/download/v${version}/peco_${platform}_${architecture}.${archive_format}"
-  local downloaded_asset_path="${tmp_download_dir}/peco.${archive_format}"
-
-  echo "∗ Downloading and installing peco..."
-  curl --fail --silent --location --create-dirs --output "$downloaded_asset_path" "$download_url"
-  mkdir -p "${install_path}/bin"
-  if [ "$platform" == "darwin" ]; then
-    unzip -j "$downloaded_asset_path" -d "${install_path}/bin"
-  elif [ "$platform" == "linux" ]; then
-    tar zxf "$downloaded_asset_path" -C "${install_path}/bin" --strip-components=1
-  fi
-  chmod +x "${install_path}/bin/peco"
-  echo "The installation was successful!"
-}
-
-install_peco "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+source "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# curl of REPO/releases/latest is a 302 to another URL
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
+if [[ $redirect_url == "$GH_REPO/releases" ]]; then
+  version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
+else
+  version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
+fi
+
+printf "%s\n" "$version"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
 
-set -Eeuo pipefail
+set -euo pipefail
 
-sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-list_all_versions() {
-  git ls-remote --tags --refs https://github.com/peco/peco.git |
-    grep -o 'refs/tags/.*' |
-    cut -d/ -f3- |
-    sed 's/^v//'
-}
+source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GH_REPO="https://github.com/peco/peco"
+TOOL_NAME="peco"
+TOOL_TEST="peco --version"
+
+fail() {
+  echo "asdf-${TOOL_NAME}: $*"
+  exit 1
+}
+
+curl_opts=(-fsSL)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+list_github_tags() {
+  git ls-remote --tags --refs "$GH_REPO" |
+    grep -o 'refs/tags/.*' | cut -d/ -f3- |
+    sed 's/^v//'
+}
+
+list_all_versions() {
+  list_github_tags
+}
+
+latest_version() {
+  list_all_versions | sort_versions | tail -n1 | xargs echo
+}
+
+resolve_version() {
+  local version="$1"
+
+  if [ "$version" = "latest" ]; then
+    version="$(latest_version)"
+  fi
+
+  echo "$version"
+}
+
+detect_platform() {
+  case "$OSTYPE" in
+    darwin*) echo "darwin" ;;
+    linux*) echo "linux" ;;
+    *) fail "Unsupported platform" ;;
+  esac
+}
+
+detect_architecture() {
+  case "$(uname -m)" in
+    x86_64) echo "amd64" ;;
+    i386 | i686) echo "386" ;;
+    arm | aarch64) echo "arm" ;;
+    arm64) echo "arm64" ;;
+    armv5* | armv6* | armv7*) echo "arm" ;;
+    *) fail "Unsupported architecture" ;;
+  esac
+}
+
+release_filename() {
+  local platform architecture archive_format
+  platform="$(detect_platform)"
+  architecture="$(detect_architecture)"
+
+  case "$platform" in
+    darwin) archive_format="zip" ;;
+    linux) archive_format="tar.gz" ;;
+  esac
+
+  echo "${TOOL_NAME}_${platform}_${architecture}.${archive_format}"
+}
+
+release_url() {
+  local version filename
+  version="$(resolve_version "$1")"
+  filename="$(release_filename)"
+  echo "${GH_REPO}/releases/download/v${version}/${filename}"
+}
+
+download_release() {
+  local version filename url
+  version="$(resolve_version "$1")"
+  filename="$2"
+  url="$(release_url "$version")"
+
+  echo "Downloading ${TOOL_NAME} release ${version}..."
+  curl "${curl_opts[@]}" -o "$filename" -C - "$url" ||
+    fail "Could not download ${url}"
+}
+
+install_version() {
+  local install_type="$1"
+  local version="$2"
+  local install_path="${3%/bin}/bin"
+  local resolved_version platform archive_format
+
+  if [ "$install_type" != "version" ]; then
+    fail "asdf-${TOOL_NAME} supports release installs only"
+  fi
+
+  resolved_version="$(resolve_version "$version")"
+  platform="$(detect_platform)"
+
+  case "$platform" in
+    darwin) archive_format="zip" ;;
+    linux) archive_format="tar.gz" ;;
+  esac
+
+  (
+    mkdir -p "$install_path"
+
+    if [ "$archive_format" = "zip" ]; then
+      unzip -j "$ASDF_DOWNLOAD_PATH/$(release_filename)" -d "$install_path" >/dev/null ||
+        fail "Could not extract archive"
+    else
+      tar zxf "$ASDF_DOWNLOAD_PATH/$(release_filename)" -C "$install_path" --strip-components=1 ||
+        fail "Could not extract archive"
+    fi
+
+    local tool_cmd
+    tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+    test -x "$install_path/$tool_cmd" ||
+      fail "Expected $install_path/$tool_cmd to be executable."
+
+    echo "${TOOL_NAME} ${resolved_version} installation was successful!"
+  ) || (
+    rm -rf "$install_path"
+    fail "An error occurred while installing ${TOOL_NAME} ${resolved_version}."
+  )
+}

--- a/test/install.bats
+++ b/test/install.bats
@@ -1,7 +1,0 @@
-#!/usr/bin/env bats
-
-@test "install command fails if the input is not version number" {
-  run asdf install peco ref
-  [ "$status" -eq 1 ]
-  echo "$output" | grep "supports release installs only"
-}

--- a/test/install.t
+++ b/test/install.t
@@ -1,0 +1,5 @@
+Install command fails if the input is not version number
+  $ asdf install peco ref
+  asdf-peco: asdf-peco supports release installs only
+  error installing version: failed to run download callback: exit status 1
+  [1]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors plugin to use shared utils and new download/latest scripts, updates workflows with pinned actions and asdf tool installs, and switches testing from bats to cram.
> 
> - **CI/Workflows**:
>   - Rename workflow and set `permissions: read-all`; simplify triggers.
>   - Pin `actions/checkout@v5` and `asdf-vm/actions` to SHAs; run plugin tests on `ubuntu-latest` and `macos-latest`.
>   - Replace Homebrew-installed tools with `asdf-vm/actions/install`; run `cram` tests and `make` targets.
> - **Plugin Scripts**:
>   - Add `lib/utils.bash` consolidating version resolution, download URL construction, platform/arch detection, and install helpers.
>   - New `bin/download` and `bin/latest-stable`; simplify `bin/install` and `bin/list-all` to use shared utils.
> - **Tooling**:
>   - Add `.tool-versions` for `shellcheck` and `shfmt`.
>   - Update `Makefile` to include `lib/*` in checks and switch `test` to `cram`.
> - **Tests**:
>   - Replace `test/install.bats` with `test/install.t` (cram) verifying non-version install failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 972f44ae5bab29637ef0afed4050915c85b1cc4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->